### PR TITLE
fix(transaction-history): :bug: Fix transaction history mapping to ma…

### DIFF
--- a/SACIT/src/pages/TransactionHistory.jsx
+++ b/SACIT/src/pages/TransactionHistory.jsx
@@ -63,12 +63,17 @@ function TransactionHistory() {
 
         const histories = response.data?.data || [];
 
-        const mappedHistories = histories.map((history) => ({
-          procedureName: history.procedure?.name || 'Sin nombre',
-          windowNumber: history.procedure?.ventanilla || 'Sin ventanilla',
-          date: history.date || 'Fecha no disponible',
-          startTime: history.createdAt?.split('T')[1]?.split('.')[0] || 'Sin hora',
-        }));
+        const mappedHistories = histories.map((history) => {
+          const formattedDate = `${String(history.date[2]).padStart(2, '0')}/${String(history.date[1]).padStart(2, '0')}/${history.date[0]}`;
+          const formattedStartTime = `${String(history.startTime[0]).padStart(2, '0')}:${String(history.startTime[1]).padStart(2, '0')}`;
+        
+          return {
+            procedureName: history.procedureName || 'Sin nombre',
+            windowNumber: history.windowNumber || 'Sin ventanilla',
+            date: formattedDate,
+            startTime: formattedStartTime,
+          };
+        });
 
         setTransactions(mappedHistories);
         setError(null);


### PR DESCRIPTION
…tch backend response structure

Updated the mapping logic in the transaction history view to correctly parse date and time arrays received from the backend. Replaced incorrect references to non-existent nested fields like procedure.name and createdAt. The displayed data now reflects accurate procedure names, window numbers, formatted appointment dates, and times.

No breaking changes